### PR TITLE
CDS use default pipe delimiter

### DIFF
--- a/content.json
+++ b/content.json
@@ -4,7 +4,6 @@
         "prop-file": "cds-model-props.yml",
         "readme-file": "README.md",
         "loading-file": "cds-file-examples.zip",
-        "list-delimiter": ",",
         "semantics": {
             "file-nodes": {
                 "file": {


### PR DESCRIPTION
Remove setting, so CDS will use default pipe "|" as delimiter.