### PR TITLE
fix: ICDC Model missing Model Version Prop

### DIFF
--- a/ICDC/1.0.0/icdc-model.yml
+++ b/ICDC/1.0.0/icdc-model.yml
@@ -2,7 +2,7 @@
 # Title case names are "reserved" (meaningful to the parser)
 # Lower case names are labels for the entities
 # document number - really a property of properties (where did this question appear)
-
+Version: v1.0.0
 Nodes:
   program:
     Desc: Within the Integrated Canine Data Commons, studies are grouped into discrete programs, based upon the origins and/or scientific nature of each study/trial. These programs may or may not directly relate to any official, e.g. NCI, funding program. The Program node contains the properties required to appropriately characterize any given ICDC program.


### PR DESCRIPTION
Add Version `v1.0.0` tag to ICDC model file. This is used by DMN to render under the page title.