### PR TITLE
Add node prop to CTDC data model

### DIFF
--- a/CTDC/1.0.0/ctdc_model_file.yaml
+++ b/CTDC/1.0.0/ctdc_model_file.yaml
@@ -2,7 +2,7 @@
 # Title case names are "reserved" (meaningful to the parser)
 # Lower case names are labels for the entities
 
-Version: v.1.1.0
+Version: v.1.0.0
 Nodes:
   # node:
   #   Desc: text
@@ -50,6 +50,7 @@ Nodes:
       - person_last_name #2179591
       - person_middle_name #2179590
       - person_orcid #10624734
+      - pi_id
   study:
     Desc: The Study node contains properties required to characterize each study/trial in terms of a title, describe when, how and why the study/trial was conducted, and provide links to additional information about the study/trial.
     Tags:


### PR DESCRIPTION
This PR adds a property to a node in the CTDC data model:
- pi_id was added to the principal investigator node
