### PR TITLE
Remove duplicate property

### DIFF
--- a/cache/ICDC/1.0.0/icdc-model.yml
+++ b/cache/ICDC/1.0.0/icdc-model.yml
@@ -228,7 +228,7 @@ Nodes:
       - registering_institution
       - initials
       - date_of_informed_consent
-      - site_short_name
+      #- site_short_name
       - veterinary_medical_center
       #- cohort_description
       - patient_subgroup


### PR DESCRIPTION
This PR removes a duplicate property, "site_short_name", from the enrollment node as it is located more appropriately in the study_site node. This was causing issues for uploading data to the enrollment node using the CRDC Data Hub validation tools.