### PR TITLE
CRDCDH-1760 Define DMN logo source

### DIFF
--- a/cache/content.json
+++ b/cache/content.json
@@ -4,6 +4,7 @@
     "prop-file": "cds-model-props.yml",
     "readme-file": "README.md",
     "loading-file": "cds-file-examples.zip",
+    "model-navigator-logo": "navigator-icon.png",
     "semantics": {
       "main-nodes": {
         "program": "Program",


### PR DESCRIPTION
This PR defines where Model Navigator should pull the CDS logo from. Currently CDS is the only DC with a model navigator icon in their repo.

This needs to be added to all tiers eventually.