### PR TITLE
Introduce "model-files" array

### DIFF
--- a/cache/content.json
+++ b/cache/content.json
@@ -1,7 +1,9 @@
 {
   "CDS": {
-    "model-file": "cds-model.yml",
-    "prop-file": "cds-model-props.yml",
+    "model-files": [
+      "cds-model.yml",
+      "cds-model-props.yml"
+    ],
     "readme-file": "README.md",
     "loading-file": "cds-file-examples.zip",
     "model-navigator-logo": "navigator-icon.png",
@@ -36,8 +38,10 @@
     ]
   },
   "ICDC": {
-    "model-file": "icdc-model.yml",
-    "prop-file": "icdc-model-props.yml",
+    "model-files": [
+      "icdc-model.yml",
+      "icdc-model-props.yml"
+    ],
     "readme-file": "Data_Model_Navigator_README.md",
     "loading-file": "ICDC_Example_Files.zip",
     "list-delimiter": "*",
@@ -66,8 +70,10 @@
     ]
   },
   "CTDC": {
-    "model-file": "ctdc_model_file.yaml",
-    "prop-file": "ctdc_model_properties_file.yaml",
+    "model-files": [
+      "ctdc_model_file.yml",
+      "ctdc_model_properties_file.yml"
+    ],
     "readme-file": "README.md",
     "loading-file": "CTDC_Example_Files.zip",
     "semantics": {
@@ -94,8 +100,10 @@
     ]
   },
   "CCDI": {
-    "model-file": "ccdi-model.yml",
-    "prop-file": "ccdi-model-props.yml",
+    "model-files": [
+      "ccdi-model.yml",
+      "ccdi-model-props.yml"
+    ],
     "readme-file": "README.md",
     "loading-file": "",
     "semantics": {
@@ -157,8 +165,9 @@
     ]
   },
   "Test MDF": {
-    "model-file": "crdc_datahub_mdf.yml",
-    "prop-file": "crdc_datahub_mdf.yml",
+    "model-files": [
+      "crdc_datahub_mdf.yml"
+    ],
     "readme-file": "README.md",
     "loading-file": "crdc_mock_data_files.zip",
     "semantics": {

--- a/cache/content.json
+++ b/cache/content.json
@@ -71,8 +71,8 @@
   },
   "CTDC": {
     "model-files": [
-      "ctdc_model_file.yml",
-      "ctdc_model_properties_file.yml"
+      "ctdc_model_file.yaml",
+      "ctdc_model_properties_file.yaml"
     ],
     "readme-file": "README.md",
     "loading-file": "CTDC_Example_Files.zip",

--- a/cache/content.json
+++ b/cache/content.json
@@ -1,5 +1,7 @@
 {
   "CDS": {
+    "model-file": "cds-model.yml",
+    "prop-file": "cds-model-props.yml",
     "model-files": [
       "cds-model.yml",
       "cds-model-props.yml"
@@ -38,6 +40,8 @@
     ]
   },
   "ICDC": {
+    "model-file": "icdc-model.yml",
+    "prop-file": "icdc-model-props.yml",
     "model-files": [
       "icdc-model.yml",
       "icdc-model-props.yml"
@@ -70,6 +74,8 @@
     ]
   },
   "CTDC": {
+    "model-file": "ctdc_model_file.yaml",
+    "prop-file": "ctdc_model_properties_file.yaml",
     "model-files": [
       "ctdc_model_file.yaml",
       "ctdc_model_properties_file.yaml"
@@ -100,6 +106,8 @@
     ]
   },
   "CCDI": {
+    "model-file": "ccdi-model.yml",
+    "prop-file": "ccdi-model-props.yml",
     "model-files": [
       "ccdi-model.yml",
       "ccdi-model-props.yml"
@@ -165,6 +173,8 @@
     ]
   },
   "Test MDF": {
+    "model-file": "crdc_datahub_mdf.yml",
+    "prop-file": "crdc_datahub_mdf.yml",
     "model-files": [
       "crdc_datahub_mdf.yml"
     ],


### PR DESCRIPTION
### Overview

This PR rewrites the usage of "model-file" and "prop-file" to become an array of file names, which is required to support an arbitrary number of files (N >= 1)

> [!Warning]
> In order to not break FE/BE until all changes are deployed, I'm leaving the model/prop files as-is. We will remove this shortly.

### Change Details (Specifics)

N/A

### Related Ticket(s)

CRDCDH-1681