### PR TITLE
Support icon mapping of categories

### DIFF
--- a/cache/content.json
+++ b/cache/content.json
@@ -8,6 +8,154 @@
     "release-notes": "version-history.md",
     "loading-file": "cds-file-examples.zip",
     "model-navigator-logo": "navigator-icon.png",
+    "model-navigator-config": {
+      "pageTitle": "GC Data Model",
+      "pdfConfig": {
+        "fileType": "pdf",
+        "prefix": "GC_",
+        "downloadPrefix": "GC_",
+        "fileTransferManifestName": "GC_",
+        "footnote": "https://hub.datacommons.cancer.gov/model-navigator/GC",
+        "landscape": true
+      },
+      "iconMap": {
+        "study": "study",
+        "case": "case",
+        "data_file": "data_file"
+      },
+      "facetFilterSearchData": [
+        {
+          "groupName": "Category",
+          "datafield": "category",
+          "section": "Filter By Nodes",
+          "tooltip": "category",
+          "show": true,
+          "checkboxItems": [
+            {
+              "name": "Case",
+              "isChecked": false,
+              "group": "category"
+            },
+            {
+              "name": "Data_File",
+              "isChecked": false,
+              "group": "category"
+            },
+            {
+              "name": "Study",
+              "isChecked": false,
+              "group": "category"
+            }
+          ]
+        },
+        {
+          "groupName": "Assignment",
+          "datafield": "assignment",
+          "section": "Filter By Nodes",
+          "tooltip": "assignment",
+          "show": true,
+          "checkboxItems": [
+            {
+              "name": "Core",
+              "isChecked": false,
+              "group": "assignment"
+            },
+            {
+              "name": "Extended",
+              "isChecked": false,
+              "group": "assignment"
+            }
+          ]
+        },
+        {
+          "groupName": "Class",
+          "datafield": "class",
+          "section": "Filter By Nodes",
+          "tooltip": "class",
+          "show": true,
+          "checkboxItems": [
+            {
+              "name": "Primary",
+              "isChecked": false,
+              "group": "class"
+            },
+            {
+              "name": "Secondary",
+              "isChecked": false,
+              "group": "class"
+            }
+          ]
+        },
+        {
+          "groupName": "Inclusion",
+          "datafield": "inclusion",
+          "section": "Filter By Property",
+          "tooltip": "inclusion",
+          "show": true,
+          "checkboxItems": [
+            {
+              "name": "Optional",
+              "isChecked": false,
+              "group": "optional"
+            },
+            {
+              "name": "Preferred",
+              "isChecked": false,
+              "group": "preferred"
+            },
+            {
+              "name": "Required",
+              "isChecked": false,
+              "group": "required"
+            }
+          ]
+        },
+        {
+          "groupName": "UI Display",
+          "datafield": "uiDisplay",
+          "section": "Filter By Property",
+          "tooltip": "inclusion",
+          "show": true,
+          "checkboxItems": [
+            {
+              "name": "no",
+              "isChecked": false,
+              "group": "no"
+            },
+            {
+              "name": "yes",
+              "isChecked": false,
+              "group": "yes"
+            }
+          ]
+        }
+      ],
+      "facetFilterSectionVariables": {
+        "Filter By Nodes": {
+          "color": "#0D71A3",
+          "checkBoxColorsOne": "#E3F4FD",
+          "checkBoxColorsTwo": "#f0f8ff",
+          "checkBoxBorderColor": "#0D71A3",
+          "height": "7px",
+          "isExpanded": true
+        },
+        "Filter By Relationship": {
+          "color": "#FF9742",
+          "checkBoxColorsOne": "#FF9742",
+          "checkBoxColorsTwo": "#FF9742",
+          "height": "7px",
+          "isExpanded": true
+        },
+        "Filter By Property": {
+          "color": "#0D71A3",
+          "checkBoxColorsOne": "#E3F4FD",
+          "checkBoxColorsTwo": "#f0f8ff",
+          "checkBoxBorderColor": "#0D71A3",
+          "height": "7px",
+          "isExpanded": true
+        }
+      }
+    },
     "semantics": {
       "main-nodes": {
         "program": "Program",
@@ -61,6 +209,182 @@
     "readme-file": "Data_Model_Navigator_README.md",
     "release-notes": "",
     "loading-file": "ICDC_Example_Files.zip",
+    "model-navigator-config": {
+      "pageTitle": "ICDC Data Model",
+      "pdfConfig": {
+        "fileType": "pdf",
+        "prefix": "ICDC_",
+        "downloadPrefix": "ICDC_",
+        "fileTransferManifestName": "ICDC_"
+      },
+      "iconMap": {
+        "administrative": "administrative",
+        "study": "study",
+        "case": "case",
+        "biospecimen": "biospecimen",
+        "clinical_trial": "clinical_trial",
+        "clinical": "clinical",
+        "analysis": "analysis",
+        "data_file": "data_file"
+      },
+      "facetFilterSearchData": [
+        {
+          "groupName": "Category",
+          "datafield": "category",
+          "section": "Filter By Nodes",
+          "tooltip": "category",
+          "show": true,
+          "checkboxItems": [
+            {
+              "name": "Administrative",
+              "isChecked": false,
+              "group": "category"
+            },
+            {
+              "name": "Analysis",
+              "isChecked": false,
+              "group": "category"
+            },
+            {
+              "name": "Biospecimen",
+              "isChecked": false,
+              "group": "category"
+            },
+            {
+              "name": "Case",
+              "isChecked": false,
+              "group": "category"
+            },
+            {
+              "name": "Clinical",
+              "isChecked": false,
+              "group": "category"
+            },
+            {
+              "name": "Clinical_Trial",
+              "isChecked": false,
+              "group": "category"
+            },
+            {
+              "name": "Data_File",
+              "isChecked": false,
+              "group": "category"
+            },
+            {
+              "name": "Study",
+              "isChecked": false,
+              "group": "category"
+            }
+          ]
+        },
+        {
+          "groupName": "Assignment",
+          "datafield": "assignment",
+          "section": "Filter By Nodes",
+          "tooltip": "assignment",
+          "show": true,
+          "checkboxItems": [
+            {
+              "name": "Core",
+              "isChecked": false,
+              "group": "assignment"
+            },
+            {
+              "name": "Extended",
+              "isChecked": false,
+              "group": "assignment"
+            }
+          ]
+        },
+        {
+          "groupName": "Class",
+          "datafield": "class",
+          "section": "Filter By Nodes",
+          "tooltip": "class",
+          "show": true,
+          "checkboxItems": [
+            {
+              "name": "Primary",
+              "isChecked": false,
+              "group": "class"
+            },
+            {
+              "name": "Secondary",
+              "isChecked": false,
+              "group": "class"
+            }
+          ]
+        },
+        {
+          "groupName": "Inclusion",
+          "datafield": "inclusion",
+          "section": "Filter By Property",
+          "tooltip": "inclusion",
+          "show": true,
+          "checkboxItems": [
+            {
+              "name": "Optional",
+              "isChecked": false,
+              "group": "optional"
+            },
+            {
+              "name": "Preferred",
+              "isChecked": false,
+              "group": "preferred"
+            },
+            {
+              "name": "Required",
+              "isChecked": false,
+              "group": "required"
+            }
+          ]
+        },
+        {
+          "groupName": "UI Display",
+          "datafield": "uiDisplay",
+          "section": "Filter By Property",
+          "tooltip": "inclusion",
+          "show": true,
+          "checkboxItems": [
+            {
+              "name": "no",
+              "isChecked": false,
+              "group": "no"
+            },
+            {
+              "name": "yes",
+              "isChecked": false,
+              "group": "yes"
+            }
+          ]
+        }
+      ],
+      "facetFilterSectionVariables": {
+        "Filter By Nodes": {
+          "color": "#0D71A3",
+          "checkBoxColorsOne": "#E3F4FD",
+          "checkBoxColorsTwo": "#f0f8ff",
+          "checkBoxBorderColor": "#0D71A3",
+          "height": "7px",
+          "isExpanded": true
+        },
+        "Filter By Relationship": {
+          "color": "#FF9742",
+          "checkBoxColorsOne": "#FF9742",
+          "checkBoxColorsTwo": "#FF9742",
+          "height": "7px",
+          "isExpanded": true
+        },
+        "Filter By Property": {
+          "color": "#0D71A3",
+          "checkBoxColorsOne": "#E3F4FD",
+          "checkBoxColorsTwo": "#f0f8ff",
+          "checkBoxBorderColor": "#0D71A3",
+          "height": "7px",
+          "isExpanded": true
+        }
+      }
+    },
     "list-delimiter": "*",
     "omit-DCF-prefix": true,
     "semantics": {
@@ -98,6 +422,184 @@
     "readme-file": "README.md",
     "release-notes": "",
     "loading-file": "CTDC_Example_Files.zip",
+    "model-navigator-config": {
+      "pageTitle": "CTDC Data Model",
+      "pdfConfig": {
+        "fileType": "pdf",
+        "prefix": "CTDC_",
+        "downloadPrefix": "CTDC_",
+        "fileTransferManifestName": "CTDC_",
+        "footnote": "https://hub.datacommons.cancer.gov/model-navigator/CTDC",
+        "landscape": true
+      },
+      "iconMap": {
+        "administrative": "administrative",
+        "study": "study",
+        "case": "case",
+        "biospecimen": "biospecimen",
+        "clinical_trial": "clinical_trial",
+        "clinical": "clinical",
+        "analysis": "analysis",
+        "data_file": "data_file"
+      },
+      "facetFilterSearchData": [
+        {
+          "groupName": "Category",
+          "datafield": "category",
+          "section": "Filter By Nodes",
+          "tooltip": "category",
+          "show": true,
+          "checkboxItems": [
+            {
+              "name": "Administrative",
+              "isChecked": false,
+              "group": "category"
+            },
+            {
+              "name": "Analysis",
+              "isChecked": false,
+              "group": "category"
+            },
+            {
+              "name": "Biospecimen",
+              "isChecked": false,
+              "group": "category"
+            },
+            {
+              "name": "Case",
+              "isChecked": false,
+              "group": "category"
+            },
+            {
+              "name": "Clinical",
+              "isChecked": false,
+              "group": "category"
+            },
+            {
+              "name": "Clinical_Trial",
+              "isChecked": false,
+              "group": "category"
+            },
+            {
+              "name": "Data_File",
+              "isChecked": false,
+              "group": "category"
+            },
+            {
+              "name": "Study",
+              "isChecked": false,
+              "group": "category"
+            }
+          ]
+        },
+        {
+          "groupName": "Assignment",
+          "datafield": "assignment",
+          "section": "Filter By Nodes",
+          "tooltip": "assignment",
+          "show": true,
+          "checkboxItems": [
+            {
+              "name": "Core",
+              "isChecked": false,
+              "group": "assignment"
+            },
+            {
+              "name": "Extended",
+              "isChecked": false,
+              "group": "assignment"
+            }
+          ]
+        },
+        {
+          "groupName": "Class",
+          "datafield": "class",
+          "section": "Filter By Nodes",
+          "tooltip": "class",
+          "show": true,
+          "checkboxItems": [
+            {
+              "name": "Primary",
+              "isChecked": false,
+              "group": "class"
+            },
+            {
+              "name": "Secondary",
+              "isChecked": false,
+              "group": "class"
+            }
+          ]
+        },
+        {
+          "groupName": "Inclusion",
+          "datafield": "inclusion",
+          "section": "Filter By Property",
+          "tooltip": "inclusion",
+          "show": true,
+          "checkboxItems": [
+            {
+              "name": "Optional",
+              "isChecked": false,
+              "group": "optional"
+            },
+            {
+              "name": "Preferred",
+              "isChecked": false,
+              "group": "preferred"
+            },
+            {
+              "name": "Required",
+              "isChecked": false,
+              "group": "required"
+            }
+          ]
+        },
+        {
+          "groupName": "UI Display",
+          "datafield": "uiDisplay",
+          "section": "Filter By Property",
+          "tooltip": "inclusion",
+          "show": true,
+          "checkboxItems": [
+            {
+              "name": "no",
+              "isChecked": false,
+              "group": "no"
+            },
+            {
+              "name": "yes",
+              "isChecked": false,
+              "group": "yes"
+            }
+          ]
+        }
+      ],
+      "facetFilterSectionVariables": {
+        "Filter By Nodes": {
+          "color": "#0D71A3",
+          "checkBoxColorsOne": "#E3F4FD",
+          "checkBoxColorsTwo": "#f0f8ff",
+          "checkBoxBorderColor": "#0D71A3",
+          "height": "7px",
+          "isExpanded": true
+        },
+        "Filter By Relationship": {
+          "color": "#FF9742",
+          "checkBoxColorsOne": "#FF9742",
+          "checkBoxColorsTwo": "#FF9742",
+          "height": "7px",
+          "isExpanded": true
+        },
+        "Filter By Property": {
+          "color": "#0D71A3",
+          "checkBoxColorsOne": "#E3F4FD",
+          "checkBoxColorsTwo": "#f0f8ff",
+          "checkBoxBorderColor": "#0D71A3",
+          "height": "7px",
+          "isExpanded": true
+        }
+      }
+    },
     "semantics": {
       "main-nodes": {
         "program": "Program",
@@ -135,6 +637,174 @@
     "readme-file": "README.md",
     "release-notes": "",
     "loading-file": "ccdi_fake_data_example_load_files.zip",
+    "model-navigator-config": {
+      "pageTitle": "CCDI Data Model",
+      "pdfConfig": {
+        "fileType": "pdf",
+        "prefix": "CCDI_",
+        "downloadPrefix": "CCDI_",
+        "fileTransferManifestName": "CCDI_",
+        "footnote": "https://hub.datacommons.cancer.gov/model-navigator/CCDI",
+        "landscape": true
+      },
+      "iconMap": {
+        "administrative": "administrative",
+        "study": "study",
+        "participant": "participant",
+        "biospecimen": "biospecimen",
+        "clinical_trial": "clinical_trial",
+        "clinical": "clinical",
+        "analysis": "analysis",
+        "data_file": "data_file"
+      },
+      "facetFilterSearchData": [
+        {
+          "groupName": "Category",
+          "datafield": "category",
+          "section": "Filter By Nodes",
+          "tooltip": "category",
+          "show": true,
+          "checkboxItems": [
+            {
+              "name": "Administrative",
+              "isChecked": false,
+              "group": "category"
+            },
+            {
+              "name": "Analysis",
+              "isChecked": false,
+              "group": "category"
+            },
+            {
+              "name": "Biospecimen",
+              "isChecked": false,
+              "group": "category"
+            },
+            {
+              "name": "Clinical",
+              "isChecked": false,
+              "group": "category"
+            },
+            {
+              "name": "Data_File",
+              "isChecked": false,
+              "group": "category"
+            },
+            {
+              "name": "Study",
+              "isChecked": false,
+              "group": "category"
+            }
+          ]
+        },
+        {
+          "groupName": "Assignment",
+          "datafield": "assignment",
+          "section": "Filter By Nodes",
+          "tooltip": "assignment",
+          "show": true,
+          "checkboxItems": [
+            {
+              "name": "Core",
+              "isChecked": false,
+              "group": "assignment"
+            },
+            {
+              "name": "Extended",
+              "isChecked": false,
+              "group": "assignment"
+            }
+          ]
+        },
+        {
+          "groupName": "Class",
+          "datafield": "class",
+          "section": "Filter By Nodes",
+          "tooltip": "class",
+          "show": true,
+          "checkboxItems": [
+            {
+              "name": "Primary",
+              "isChecked": false,
+              "group": "class"
+            },
+            {
+              "name": "Secondary",
+              "isChecked": false,
+              "group": "class"
+            }
+          ]
+        },
+        {
+          "groupName": "Inclusion",
+          "datafield": "inclusion",
+          "section": "Filter By Property",
+          "tooltip": "inclusion",
+          "show": true,
+          "checkboxItems": [
+            {
+              "name": "Optional",
+              "isChecked": false,
+              "group": "optional"
+            },
+            {
+              "name": "Preferred",
+              "isChecked": false,
+              "group": "preferred"
+            },
+            {
+              "name": "Required",
+              "isChecked": false,
+              "group": "required"
+            }
+          ]
+        },
+        {
+          "groupName": "UI Display",
+          "datafield": "uiDisplay",
+          "section": "Filter By Property",
+          "tooltip": "inclusion",
+          "show": true,
+          "checkboxItems": [
+            {
+              "name": "no",
+              "isChecked": false,
+              "group": "no"
+            },
+            {
+              "name": "yes",
+              "isChecked": false,
+              "group": "yes"
+            }
+          ]
+        }
+      ],
+      "facetFilterSectionVariables": {
+        "Filter By Nodes": {
+          "color": "#0D71A3",
+          "checkBoxColorsOne": "#E3F4FD",
+          "checkBoxColorsTwo": "#f0f8ff",
+          "checkBoxBorderColor": "#0D71A3",
+          "height": "7px",
+          "isExpanded": true
+        },
+        "Filter By Relationship": {
+          "color": "#FF9742",
+          "checkBoxColorsOne": "#FF9742",
+          "checkBoxColorsTwo": "#FF9742",
+          "height": "7px",
+          "isExpanded": true
+        },
+        "Filter By Property": {
+          "color": "#0D71A3",
+          "checkBoxColorsOne": "#E3F4FD",
+          "checkBoxColorsTwo": "#f0f8ff",
+          "checkBoxBorderColor": "#0D71A3",
+          "height": "7px",
+          "isExpanded": true
+        }
+      }
+    },
     "semantics": {
       "main-nodes": {
         "study": "Study",
@@ -204,6 +874,142 @@
     "readme-file": "README.md",
     "release-notes": "release-notes.md",
     "loading-file": "crdc_mock_data_files.zip",
+    "model-navigator-config": {
+      "pageTitle": "Test MDF Data Model",
+      "pdfConfig": {
+        "fileType": "pdf",
+        "prefix": "Test MDF_",
+        "downloadPrefix": "Test MDF_",
+        "fileTransferManifestName": "Test MDF_",
+        "footnote": "https://hub.datacommons.cancer.gov/model-navigator/Test MDF",
+        "landscape": true
+      },
+      "iconMap": {
+        "clinical": "clinical"
+      },
+      "facetFilterSearchData": [
+        {
+          "groupName": "Category",
+          "datafield": "category",
+          "section": "Filter By Nodes",
+          "tooltip": "category",
+          "show": true,
+          "checkboxItems": [
+            {
+              "name": "Clinical",
+              "isChecked": false,
+              "group": "category"
+            }
+          ]
+        },
+        {
+          "groupName": "Assignment",
+          "datafield": "assignment",
+          "section": "Filter By Nodes",
+          "tooltip": "assignment",
+          "show": true,
+          "checkboxItems": [
+            {
+              "name": "Core",
+              "isChecked": false,
+              "group": "assignment"
+            },
+            {
+              "name": "Extended",
+              "isChecked": false,
+              "group": "assignment"
+            }
+          ]
+        },
+        {
+          "groupName": "Class",
+          "datafield": "class",
+          "section": "Filter By Nodes",
+          "tooltip": "class",
+          "show": true,
+          "checkboxItems": [
+            {
+              "name": "Primary",
+              "isChecked": false,
+              "group": "class"
+            },
+            {
+              "name": "Secondary",
+              "isChecked": false,
+              "group": "class"
+            }
+          ]
+        },
+        {
+          "groupName": "Inclusion",
+          "datafield": "inclusion",
+          "section": "Filter By Property",
+          "tooltip": "inclusion",
+          "show": true,
+          "checkboxItems": [
+            {
+              "name": "Optional",
+              "isChecked": false,
+              "group": "optional"
+            },
+            {
+              "name": "Preferred",
+              "isChecked": false,
+              "group": "preferred"
+            },
+            {
+              "name": "Required",
+              "isChecked": false,
+              "group": "required"
+            }
+          ]
+        },
+        {
+          "groupName": "UI Display",
+          "datafield": "uiDisplay",
+          "section": "Filter By Property",
+          "tooltip": "inclusion",
+          "show": true,
+          "checkboxItems": [
+            {
+              "name": "no",
+              "isChecked": false,
+              "group": "no"
+            },
+            {
+              "name": "yes",
+              "isChecked": false,
+              "group": "yes"
+            }
+          ]
+        }
+      ],
+      "facetFilterSectionVariables": {
+        "Filter By Nodes": {
+          "color": "#0D71A3",
+          "checkBoxColorsOne": "#E3F4FD",
+          "checkBoxColorsTwo": "#f0f8ff",
+          "checkBoxBorderColor": "#0D71A3",
+          "height": "7px",
+          "isExpanded": true
+        },
+        "Filter By Relationship": {
+          "color": "#FF9742",
+          "checkBoxColorsOne": "#FF9742",
+          "checkBoxColorsTwo": "#FF9742",
+          "height": "7px",
+          "isExpanded": true
+        },
+        "Filter By Property": {
+          "color": "#0D71A3",
+          "checkBoxColorsOne": "#E3F4FD",
+          "checkBoxColorsTwo": "#f0f8ff",
+          "checkBoxBorderColor": "#0D71A3",
+          "height": "7px",
+          "isExpanded": true
+        }
+      }
+    },
     "semantics": {
       "main-nodes": {
         "study": "Study",
@@ -232,6 +1038,7 @@
     "readme-file": "README.md",
     "release-notes": "",
     "loading-file": "hidden_model_examples.zip",
+    "model-navigator-config": null,
     "semantics": {
       "main-nodes": {
         "study": "Study",

--- a/cache/content.json
+++ b/cache/content.json
@@ -215,7 +215,9 @@
         "fileType": "pdf",
         "prefix": "ICDC_",
         "downloadPrefix": "ICDC_",
-        "fileTransferManifestName": "ICDC_"
+        "fileTransferManifestName": "ICDC_",
+        "footnote": "https://hub.datacommons.cancer.gov/model-navigator/ICDC",
+        "landscape": true
       },
       "iconMap": {
         "administrative": "administrative",


### PR DESCRIPTION
### Overview

This PR updates the content manifest file to include two things:

- The Data Model Navigator configuration object (previously apart of the CRDC-DH frontend repo)
- The icon mapping configuration for MDF node categories to an icon (`category` -> `icon name`)

List of natively supported icons in DMN now: https://github.com/CBIIT/Data-Model-Navigator/tree/CRDC-DH?tab=readme-ov-file#supported-icons

### Change Details (Specifics)

N/A

### Related Ticket(s)

CRDCDH-2600 (Task)