### PR TITLE
fix: ICDC Icon Mapping & missing logos

### DIFF
--- a/cache/content.json
+++ b/cache/content.json
@@ -222,6 +222,7 @@
     "readme-file": "Data_Model_Navigator_README.md",
     "release-notes": "version.md",
     "loading-file": "ICDC_Example_Files.zip",
+    "model-navigator-logo": "navigator-icon.svg",
     "model-navigator-config": {
       "pageTitle": "ICDC Data Model",
       "pdfConfig": {
@@ -237,7 +238,7 @@
         "study": "study",
         "case": "case",
         "biospecimen": "biospecimen",
-        "clinical_trial": "clinical_trial",
+        "clinical_trial": "clinical_trial_canine",
         "clinical": "clinical",
         "analysis": "analysis",
         "data_file": "data_file"
@@ -440,6 +441,7 @@
     "readme-file": "README.md",
     "release-notes": "version-history.md",
     "loading-file": "CTDC_Example_Files.zip",
+    "model-navigator-logo": "logo.png",
     "model-navigator-config": {
       "pageTitle": "CTDC Data Model",
       "pdfConfig": {
@@ -674,6 +676,7 @@
     "readme-file": "README.md",
     "release-notes": "",
     "loading-file": "ccdi_fake_data_example_load_files.zip",
+    "model-navigator-logo": "CCDI-navigator-icon.png",
     "model-navigator-config": {
       "pageTitle": "CCDI Data Model",
       "pdfConfig": {


### PR DESCRIPTION
Refer to CRDCDH-3422

<img width="1497" height="553" alt="Screenshot 2026-01-15 at 10 26 01 AM" src="https://github.com/user-attachments/assets/2a2a4af8-a301-434d-9299-ec39dff18e08" />
<img width="1497" height="228" alt="Screenshot 2026-01-15 at 10 26 44 AM" src="https://github.com/user-attachments/assets/63513019-f39d-4544-8f45-952b459fc5a0" />
<img width="1497" height="228" alt="Screenshot 2026-01-15 at 10 26 59 AM" src="https://github.com/user-attachments/assets/59cc799c-9f2b-43f5-bc2c-cb4ad975c7e3" />
