### PR TITLE
Remove version-history from GC, CTDC

### DIFF
--- a/cache/content.json
+++ b/cache/content.json
@@ -5,7 +5,6 @@
       "cds-model-props.yml"
     ],
     "readme-file": "README.md",
-    "release-notes": "version-history.md",
     "loading-file": "cds-file-examples.zip",
     "model-navigator-logo": "navigator-icon.png",
     "model-navigator-config": {
@@ -439,7 +438,6 @@
       "ctdc_model_properties_file.yaml"
     ],
     "readme-file": "README.md",
-    "release-notes": "version-history.md",
     "loading-file": "CTDC_Example_Files.zip",
     "model-navigator-logo": "logo.png",
     "model-navigator-config": {


### PR DESCRIPTION
No longer needed to be directly specified for GC and CTDC because they use the correct name. For ICDC, we still need to specify the custom document name they have.